### PR TITLE
Disable placeholderPattern for Babel 7 compat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export default function plugin({ types: t, template }) {
-  const expr = template('"production" !== process.env.NODE_ENV')();
+  const expr = template('"production" !== process.env.NODE_ENV', { placeholderPattern: false })();
   const bool = t.booleanLiteral('production' !== process.env.NODE_ENV);
 
   return {


### PR DESCRIPTION
Babel7 treats all caps names as variables by default, and will throw an error if they're not used as it expects. This works around that, by disabling the placeholderPattern (documented here: https://www.npmjs.com/package/@babel/template). This means this should work for Babel 7 without issue, and the option is safely ignored for Babel 6.